### PR TITLE
h) deleted startOpYear/startOpMonth

### DIFF
--- a/src/Cyder.cpp
+++ b/src/Cyder.cpp
@@ -69,8 +69,6 @@ Cyder::Cyder(cyclus::Context* ctx)
   t_lim_(500),
   inventory_size_(70000),
   lifetime_(10000),
-  start_op_yr_(2000),
-  start_op_mo_(1),
   is_full_(false),
   stocks_(std::deque< WasteStream >()), 
   inventory_(std::deque< WasteStream >()),
@@ -92,8 +90,6 @@ Cyder::Cyder(cyclus::Context* ctx)
   mapVars("limiting_temp", &t_lim_);
   mapVars("inventorysize", &inventory_size_);
   mapVars("lifetime", &lifetime_);
-  mapVars("startOperYear", &start_op_yr_);
-  mapVars("startOperMonth", &start_op_mo_);
 }
 
 #pragma cyclus clone cyder::cyder

--- a/src/Cyder.h
+++ b/src/Cyder.h
@@ -38,8 +38,6 @@ typedef std::pair<mat_rsrc_ptr, std::string> WasteStream;
    parameters:
    - double capacity : The production capacity of the facility (units vary, but 
    typically kg/month). *Question:* Do we want to allow this to be infinite?  
-   - int startOpYear : The year in which the facility begins to operate .
-   - int startOpMonth : The month in which the facility begins to operate .
    - int lifeTime : The length of time that the facility operates (months).
    - std::string inCommod : One or more types of commodity that this facility accepts.
    - Component`*` component : One or more types of component that facility contains

--- a/src/Cyder.h
+++ b/src/Cyder.h
@@ -339,32 +339,7 @@ protected:
                         "doc": "repository lifetime in months"}
     int lifetime_;
 
-    /**
-       The year in which operation of the facility begins.
-       (maybe this should just be in the deployment description?)
-     */
-    #pragma cyclus var {"default": 1e299, \
-                        "tooltip": "repository operation start year", \
-                        "units": "year", \
-                        "uilabel": "Start Year", \
-                        "uitype": "range", \
-                        "range": [0.0, 1e299], \
-                        "doc": "repository operation start year"}
-    int start_op_yr_;
 
-    /**
-       The month in which operation of the facility begins.
-       (maybe this should just be in the deployment description?)
-     */
-    #pragma cyclus var {"default": 1e299, \
-                        "tooltip": "repository operation start month", \
-                        "units": "month", \
-                        "uilabel": "Start Month", \
-                        "uitype": "range", \
-                        "range": [0.0, 1e299], \
-                        "doc": "repository operation start month"}
-    int start_op_mo_;
-x
     /**
        The radius at which the thermally limiting temperature takes effect [m]
      */

--- a/src/Testing/CyderTests.cpp
+++ b/src/Testing/CyderTests.cpp
@@ -25,8 +25,6 @@ void CyderTest::SetUp(){
   in_commod_ = "in_commod";
   inventory_size_ = 70000;
   lifetime_ = 3000000;
-  start_op_yr_ = 1; 
-  start_op_mo_ = 1;
   wfname_ = "wf_name";
   wfinnerradius_ = 0;
   wfouterradius_ = 1;
@@ -90,8 +88,6 @@ Cyder* CyderTest::initSrcFacility(){
          << "  <incommodity>" << in_commod_ << "</incommodity>"
          << "  <inventorysize>" << inventory_size_ << "</inventorysize>"
          << "  <lifetime>" << lifetime_ << "</lifetime>"
-         << "  <startOperMonth>" << start_op_mo_ << "</startOperMonth>"
-         << "  <startOperYear>" << start_op_yr_ << "</startOperYear>"
          << "  <thermalmodel>"
          << "    <STCThermal/>"
          << "  </thermalmodel>"

--- a/src/Testing/CyderTests.h
+++ b/src/Testing/CyderTests.h
@@ -12,7 +12,7 @@ protected:
   
   Cyder* src_facility_;
   Cyder* clone_facility_;
-  int lifetime_,start_op_yr_,start_op_mo_, time_;
+  int lifetime_, time_;
   double wfinnerradius_, wfouterradius_;
   double wpinnerradius_, wpouterradius_; 
   double binnerradius_, bouterradius_;


### PR DESCRIPTION
deleted startOpYear/startOpMonth.

the startOpYear / startOpMonth variables were only in the .h file, according to grep